### PR TITLE
Poprawa ekranu pomocy 

### DIFF
--- a/trojkaty.java
+++ b/trojkaty.java
@@ -23,7 +23,7 @@ class Trojkaty {
     /** Wyświetla ekran pomocy */
     public static void pomoc(){
         System.out.println("Acme INC. (C) 2022");
-        System.out.println("Program do rozpoznawania rodzaju trójkąra");
+        System.out.println("Program do rozpoznawania rodzaju trójkąta");
         System.out.println("Uruchom z trzema argumentami liczbowymi - długość boków trójkąta");
     }
     /** Glowna funkcja */


### PR DESCRIPTION
W funkcji pomoc popraw wyraz "trójkąra" na "trójkąta"